### PR TITLE
Fix violations of Sonar rule 2095

### DIFF
--- a/src/test/java/com/github/lianjiatech/retrofit/spring/boot/test/DownloadTest.java
+++ b/src/test/java/com/github/lianjiatech/retrofit/spring/boot/test/DownloadTest.java
@@ -42,13 +42,14 @@ public class DownloadTest {
         if (!file.exists()) {
             file.createNewFile();
         }
-        FileOutputStream fos = new FileOutputStream(file);
-        byte[] b = new byte[1024];
-        int length;
-        while ((length = is.read(b)) > 0) {
-            fos.write(b, 0, length);
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            byte[] b = new byte[1024];
+            int length;
+            while ((length = is.read(b)) > 0) {
+                fos.write(b, 0, length);
+            } 
+            is.close();
+            fos.close();
         }
-        is.close();
-        fos.close();
     }
 }


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2095: 'Resources should be closed'](https://rules.sonarsource.com/java/RSPEC-2095). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2095](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#resources-should-be-closed-sonar-rule-2095).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.