### PR TITLE
Update log4j 2.17.0 to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
         <spring-boot.version>2.1.1.RELEASE</spring-boot.version>
-        <log4j-core.version>2.12.1</log4j-core.version>
+        <log4j-core.version>2.17.1</log4j-core.version>
         <okhttp3.version>3.14.9</okhttp3.version>
         <okio.version>1.17.5</okio.version>
         <sentinel.version>1.6.3</sentinel.version>


### PR DESCRIPTION
Please refer to the articles below.

- https://securityaffairs.co/wordpress/126135/hacking/new-apache-log4j-cve-2021-44832.html

- https://snyk.io/blog/new-log4j-2-17-1-fixes-cve-2021-44832-remote-code-execution-but-its-not-as-bad-as-it-sounds/