### PR TITLE
修改log-level=error的时候项目每次请求报错问题

### DIFF
--- a/src/main/java/com/github/lianjiatech/retrofit/spring/boot/log/LoggingInterceptor.java
+++ b/src/main/java/com/github/lianjiatech/retrofit/spring/boot/log/LoggingInterceptor.java
@@ -96,6 +96,9 @@ public class LoggingInterceptor implements Interceptor {
         }
 
         public void flush() {
+            if(buffer.toString().equals(System.lineSeparator())){
+                return;
+            }
             delegate.log(buffer.toString());
             buffer = new StringBuilder(System.lineSeparator());
         }


### PR DESCRIPTION
当配置文件为
retrofit.auto-set-prototype-scope-for-path-math-interceptor = false retrofit.global-log.enable=true
retrofit.global-log.log-strategy=None
retrofit.global-log.log-level=error

项目运行过程中,每次请求总是有以下错误
2024-03-07 10:26:58.865 ERROR 40676 --- [nio-8090-exec-1] c.g.l.r.s.boot.log.LoggingInterceptor    : 



排查发现主要是，当聚合模式开启时候
buffer默认初始化的时候加了一个回车换行符导致

我使用的版本是 2.3.14 ， 但是日志模块原则上跟Springboot的版本无关。 请 `添明` 判断代码添加位置是否合理。