### PR TITLE
Add max idle connections configuration to Retrofit client - 3.x

### DIFF
--- a/src/main/java/com/github/lianjiatech/retrofit/spring/boot/core/Constants.java
+++ b/src/main/java/com/github/lianjiatech/retrofit/spring/boot/core/Constants.java
@@ -21,4 +21,6 @@ public interface Constants {
     String DEFAULT_CIRCUIT_BREAKER_CONFIG = "defaultCircuitBreakerConfig";
 
     int INVALID_TIMEOUT_VALUE = -1;
+
+    int MAX_IDLE_CONNECTIONS = 5;
 }

--- a/src/main/java/com/github/lianjiatech/retrofit/spring/boot/core/RetrofitClient.java
+++ b/src/main/java/com/github/lianjiatech/retrofit/spring/boot/core/RetrofitClient.java
@@ -2,6 +2,7 @@ package com.github.lianjiatech.retrofit.spring.boot.core;
 
 import java.lang.annotation.*;
 
+import okhttp3.ConnectionPool;
 import retrofit2.CallAdapter;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
@@ -153,5 +154,14 @@ public @interface RetrofitClient {
      *
      */
     int callTimeoutMs() default Constants.INVALID_TIMEOUT_VALUE;
+
+    /**
+     * Sets the default max idle connections for client.
+     *
+     * @return maxIdleConnections
+     * @see ConnectionPool#ConnectionPool()
+     */
+    int maxIdleConnections() default Constants.MAX_IDLE_CONNECTIONS;
+
 
 }

--- a/src/main/java/com/github/lianjiatech/retrofit/spring/boot/core/RetrofitFactoryBean.java
+++ b/src/main/java/com/github/lianjiatech/retrofit/spring/boot/core/RetrofitFactoryBean.java
@@ -17,6 +17,7 @@ import com.github.lianjiatech.retrofit.spring.boot.interceptor.Intercepts;
 import com.github.lianjiatech.retrofit.spring.boot.interceptor.NetworkInterceptor;
 import com.github.lianjiatech.retrofit.spring.boot.util.AppContextUtils;
 import com.github.lianjiatech.retrofit.spring.boot.util.BeanExtendUtils;
+import okhttp3.ConnectionPool;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import org.springframework.beans.BeansException;
@@ -115,6 +116,7 @@ public class RetrofitFactoryBean<T> implements FactoryBean<T>, EnvironmentAware,
                     ? globalTimeout.getCallTimeoutMs() : retrofitClient.callTimeoutMs();
 
             okHttpClientBuilder = new OkHttpClient.Builder()
+                    .connectionPool(new ConnectionPool(retrofitClient.maxIdleConnections(), 5, TimeUnit.MINUTES))
                     .connectTimeout(connectTimeoutMs, TimeUnit.MILLISECONDS)
                     .readTimeout(readTimeoutMs, TimeUnit.MILLISECONDS)
                     .writeTimeout(writeTimeoutMs, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
<img width="949" height="151" alt="image" src="https://github.com/user-attachments/assets/e8746464-ccf2-477d-9f66-cbfefbcc440d" />

<img width="936" height="419" alt="image" src="https://github.com/user-attachments/assets/1d65adaa-ff34-473d-bd7f-1e458bedb57b" />

Now you can use the @RetrofitClient annotation to configure the connection pool for the client

<img width="950" height="106" alt="image" src="https://github.com/user-attachments/assets/35ccec47-3e73-431a-867f-6b618c729dea" />
